### PR TITLE
Fix warnings: Add _default_source for portablity and default chartInterval

### DIFF
--- a/stonky.c
+++ b/stonky.c
@@ -26,6 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* Adding these for portablity */
+#define _GNU_SOURCE
+#define _BSD_SOURCE
+/* modern glibc will complain about the above if it doesn't see this. */
+#define _DEFAULT_SOURCE
+
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -769,6 +775,7 @@ void botHandlePriceRequest(botRequest *br, sds symbol) {
 void botHandleChartRequest(botRequest *br, sds symbol, sds range) {
     /* Select the Yahoo chart API parameters according to the
      * requested interval. */
+    /* api_range and api_internal defaults to 1d and 5m respectively */
     char *api_range, *api_interval;
     if (!strcasecmp(range,"1d")) {
         api_range = "1d";
@@ -785,6 +792,9 @@ void botHandleChartRequest(botRequest *br, sds symbol, sds range) {
     } else if (!strcasecmp(range,"1y")) {
         api_range = "1y";
         api_interval = "5d";
+    } else {
+        api_range = "1d";
+        api_interval = "5m";
     }
 
     ydata *yd = getYahooData(YDATA_TS,symbol,api_range,api_interval);


### PR DESCRIPTION
Hi @antirez 
Following PR fixes GCC warnings for all the **implicit declaration** and **uninitialized** ptrs.

* Add `#define _BSD_SOURCE` and `#define _DEFAULT_SOURCE` for extensions portablity.
* **botHandleChartRequest**: Defaults `api_range` and `api_internal` to `1d` and `5m` respectively.
